### PR TITLE
Manage CHANGELOG with chg(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,34 @@
-## 0.4.4 (Unreleased)
+CHANGELOG
+=========
 
-## 0.4.3 (Released June 5th, 2019)
+## HEAD (Unreleased)
+_(none)_
 
-- Update to v2.2.1 of the Packet.net Terraform provider.
+---
 
-## 0.4.2 (Released May 28th, 2019)
+## 0.4.3 (2019-04-05)
+* Update to v2.2.1 of the Packet.net provider
 
-- Update to v2.2.0 of the Packet.net Terraform provider.
+## 0.4.2 (2019-05-28)
+* Update to v2.2.0 of the Packet.net provider
 
-## 0.4.1 (Released April 30th, 2019)
+## 0.4.1 (2019-04-30)
+* Update to v2.1.0 of the Packet.net provider
+* BREAKING: the `facility` property has been deprecated in favour of the `facilities` property throughout the provider
 
-### Breaking Changes
+## 0.3.2 (2019-04-22)
+* Update to v1.6.1 of the Packet.net Terraform provider
 
-- Update to v2.1.0 of the Packet.net Terraform provider.
-  **Please Note** this deprecates the use of `facility` in favour of using `facilities`
+## 0.3.1 (2019-04-05)
+* Update to v1.6.0 of the Packet.net Terraform provider
 
-## 0.3.2 (Released April 22nd, 2019)
+## 0.3.0 (2019-03-06)
+* Update to the latest version of the `pulumi` SDK
 
-### Improvements
+## 0.2.0 (2019-02-22)
+* Update to v1.4.1 of the Packet.net Terraform provider
+* Add support for the `deleteBeforeReplace` resource option and improved delete-before-replace behaviour introduced in Pulumi v0.16.14
 
-- Update to v1.7.2 of the Packet.net Terraform provider.
+## 0.1.0 (2019-02-01)
+* Initial Release
 
-## 0.3.1 (Released April 5th, 2019)
-
-### Improvements
-
-- Update to v1.6.0 of the Packet.net Terraform provider.
-
-## 0.3.0 (Released March 6th, 2019)
-
-### Improvements
-
-- Depend on the latest version of `@pulumi/pulumi`.
-
-## 0.2.0 (Released February 22nd, 2019)
-
-### Improvements
-
-- Updated to version 1.4.1 of the Packet.net Terraform provider.
-
-- Support for the `deleteBeforeReplace` resource option and improved
-  delete-before-replace behaviour introduced in [Pulumi
-  0.16.14](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#01614-released-january-31st-2019).
-
-## 0.1.0 (Released February 1st, 2019)
-
-Initial release!


### PR DESCRIPTION
This commit reformats the CHANGELOG.md file to be in format which can be managed using https://github.com/heff/chg/, in order to make it manageable from scripts.