### PR TITLE
Update pulumi-terraform to 65eb36cfeb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform v0.12.0-rc1.0.20190509225429-28b2383eacae
 	github.com/pkg/errors v0.8.0
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d
+	github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
 	github.com/terraform-providers/terraform-provider-packet v0.0.0-20190605115255-d3f15eddd25d
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,8 @@ github.com/pulumi/pulumi-terraform v0.18.2 h1:87eFAASBmHCH41OlcGZAydGgSYFTIPFoKj
 github.com/pulumi/pulumi-terraform v0.18.2/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d h1:ObOJbSfTnJ8IzrTw7pVcckU+R0yMEyV4mXdQ+xH+j8w=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
+github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1 h1:T9LXyH3t0tAwDowydQDIntfLEsPsowtmzZd7Z/6YAIw=
+github.com/pulumi/pulumi-terraform v0.18.3-0.20190620225652-65eb36cfebb1/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54/go.mod h1:1NF/j951kWm+ZnRXpOkBqweImgwhlzFVwTA4A0V7TEU=

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -22,13 +22,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-   $ npm install @pulumi/packet
+    $ npm install @pulumi/packet
 
 or ``yarn``:
 
 ::
 
-   $ yarn add @pulumi/packet
+    $ yarn add @pulumi/packet
 
 Python
 ~~~~~~
@@ -37,7 +37,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-   $ pip install pulumi_packet
+    $ pip install pulumi_packet
 
 Go
 ~~
@@ -46,7 +46,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-   $ go get github.com/pulumi/pulumi-packet/sdk/go/...
+    $ go get github.com/pulumi/pulumi-packet/sdk/go/...
 
 Reference
 ---------


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [65eb36cfeb](https://github.com/pulumi/pulumi-terraform/commit/65eb36cfebb1c6261d1859e75b33fd01b90cbba0), and re-runs code generation